### PR TITLE
ThreadLocal未remove引发的OOM问题

### DIFF
--- a/src/main/java/com/github/hcsp/MyController.java
+++ b/src/main/java/com/github/hcsp/MyController.java
@@ -17,7 +17,12 @@ public class MyController {
     @GetMapping("/index")
     @ResponseBody
     public String index() {
-        aService.service(new Entity());
-        return "OK";
+        Entity entity = new Entity();
+        try {
+            aService.service(entity);
+            return "OK";
+        } finally {
+            entity.getThreadLocal().remove();
+        }
     }
 }


### PR DESCRIPTION
<!--- 你要打开的这个Pull request(PR)的类型是？默认是题目解答，如果你正在修复当前的仓库的缺陷，请选择对应的类型 -->

- [x] 这个PR解答了当前仓库中的题目（机器人会自动判题并合并当前PR）
- [ ] 这个PR修复了当前仓库中的一些代码缺陷（机器人不会判题，而是由管理员来处理当前PR）

1. 首先确定堆内存大小，fa发现 -Xmx为64m, 此时默认情况下老年代占2/3,约为43m
![image](https://user-images.githubusercontent.com/33724768/74703700-f92fbe00-5248-11ea-9081-203b0886c017.png)

2. 分析dump , 发现4个Entity实例，其中前三个大小约为10m, 第4个大小为24byte, 程序中一个Entity实例的data属性就是一个10m大小的byte[], 所以发生OOM的原因可以初步定为为第四次创建Entity实例时，因申请空间创建byte[]报堆内存空间不足而发生Fu'll GC, 但前三个entity实例因为仍然存储在ThreadLocal中ThreadLocalMap中，所以仍然是可达对象，未被GC回收
[image](https://user-images.githubusercontent.com/33724768/74703605-ad7d1480-5248-11ea-92f2-0686675b0e8e.png)

3. 解决办法：每次执行完service后，释放调用ThreadLocal的remove方法，使得entity实例变成不可达对象，在下次GC时会被清除，释放内存空间。



