### PR TITLE
内存泄漏

### DIFF
--- a/src/main/java/com/github/hcsp/MyController.java
+++ b/src/main/java/com/github/hcsp/MyController.java
@@ -17,7 +17,12 @@ public class MyController {
     @GetMapping("/index")
     @ResponseBody
     public String index() {
-        aService.service(new Entity());
+        Entity e = new Entity();
+        try {
+            aService.service(e);
+        } finally {
+            e.getThreadLocal().remove();
+        }
         return "OK";
     }
 }


### PR DESCRIPTION
ThreadLocal使用不当，没有remove对象，导致堆内存内存溢出

<!--- 你要打开的这个Pull request(PR)的类型是？默认是题目解答，如果你正在修复当前的仓库的缺陷，请选择对应的类型 -->

- [x] 这个PR解答了当前仓库中的题目（机器人会自动判题并合并当前PR）
- [ ] 这个PR修复了当前仓库中的一些代码缺陷（机器人不会判题，而是由管理员来处理当前PR）

